### PR TITLE
`useLocationStateValue`/`useLocationStateValue`, add `refine` option

### DIFF
--- a/apps/example-next/package.json
+++ b/apps/example-next/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@location-state/core": "workspace:*",
+    "@location-state/next": "workspace:*",
     "@types/node": "20.5.6",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
@@ -18,7 +20,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.2.2",
-    "@location-state/core": "workspace:*",
-    "@location-state/next": "workspace:*"
+    "zod": "3.22.2"
   }
 }

--- a/apps/example-next/src/components/Counter.tsx
+++ b/apps/example-next/src/components/Counter.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { useLocationState, StoreName } from "@location-state/core";
-import { z } from "zod";
+import { useLocationState, StoreName, Refine } from "@location-state/core";
+import { z, ZodType } from "zod";
 
-const schema = z.number();
+const zodRefine =
+  <T extends unknown>(schema: ZodType<T>): Refine<T> =>
+  (value) => {
+    const result = schema.safeParse(value);
+    return result.success ? result.data : undefined;
+  };
 
 export function Counter({ storeName }: { storeName: StoreName }) {
   const [counter, setCounter] = useLocationState({
     name: "counter",
     defaultValue: 0,
     storeName,
-    refine: (value) => {
-      const result = schema.safeParse(value);
-      if (result.success) {
-        return result.data;
-      }
-      return undefined;
-    },
+    refine: zodRefine(z.number()),
   });
   console.debug("rendered Counter", { storeName, counter });
 

--- a/apps/example-next/src/components/Counter.tsx
+++ b/apps/example-next/src/components/Counter.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { useLocationState, StoreName } from "@location-state/core";
+import { z } from "zod";
+
+const schema = z.number();
 
 export function Counter({ storeName }: { storeName: StoreName }) {
   const [counter, setCounter] = useLocationState({
     name: "counter",
     defaultValue: 0,
     storeName,
+    refine: (value) => {
+      const result = schema.safeParse(value);
+      if (result.success) {
+        return result.data;
+      }
+      return undefined;
+    },
   });
   console.debug("rendered Counter", { storeName, counter });
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "8.47.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-react": "7.33.2",
+    "eslint-plugin-react-hooks": "4.6.0",
     "husky": "8.0.3",
     "jest": "29.6.1",
     "navigation-api-types": "0.3.1",

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -7,6 +7,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "prettier",
   ],
   parser: "@typescript-eslint/parser",
@@ -18,5 +19,11 @@ module.exports = {
   rules: {
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
+    "react-hooks/exhaustive-deps": "error",
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
   },
 };

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -33,7 +33,7 @@ describe("using `useLocationState`.", () => {
         <h1>count: {count}</h1>
         <button onClick={() => setCount(count + 1)}>increment</button>
         <button onClick={() => setCount((prev) => prev + 1)}>
-          increment with callback
+          increment with updater
         </button>
       </div>
     );
@@ -56,12 +56,12 @@ describe("using `useLocationState`.", () => {
     expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
   });
 
-  test("`count` can be updated with callback.", async () => {
+  test("`count` can be updated with updater.", async () => {
     // Arrange
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(
-      await screen.findByRole("button", { name: "increment with callback" }),
+      await screen.findByRole("button", { name: "increment with updater" }),
     );
     // Assert
     expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
@@ -122,6 +122,8 @@ describe("using `useLocationStateValue`.", () => {
       expect(screen.getByRole("heading")).toHaveTextContent("count: 2"),
     );
   });
+
+  test.todo(`When store's value is changed, component is re-rendered.`);
 });
 
 describe("using `useLocationSetState`.", () => {
@@ -160,5 +162,6 @@ describe("using `useLocationSetState`.", () => {
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Assert
     expect(screen.getByRole("heading")).toHaveTextContent("rendered: 1");
+    // todo: assert store's value updated.
   });
 });

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -8,6 +8,7 @@ import { LocationStateProvider } from "./provider";
 import { createNavigationMock } from "test-utils";
 import { renderWithUser } from "test-utils";
 import { screen, waitFor } from "@testing-library/react";
+import { locationKeyPrefix } from "./stores";
 
 const mockNavigation = createNavigationMock("/");
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -47,7 +48,6 @@ describe("`useLocationState` used.", () => {
 
   test("`count` can be updated.", async () => {
     // Arrange
-    mockNavigation.navigate("/count-update");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(await screen.findByRole("button", { name: "increment" }));
@@ -57,7 +57,6 @@ describe("`useLocationState` used.", () => {
 
   test("`count` can be updated with callback.", async () => {
     // Arrange
-    mockNavigation.navigate("/count-update");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(
@@ -69,7 +68,6 @@ describe("`useLocationState` used.", () => {
 
   test("`count` is reset at navigation.", async () => {
     // Arrange
-    mockNavigation.navigate("/count-reset");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Act
@@ -77,6 +75,18 @@ describe("`useLocationState` used.", () => {
     // Assert
     await waitFor(() =>
       expect(screen.getByRole("heading")).toHaveTextContent("count: 0"),
+    );
+  });
+
+  test("If there is a value in sessionStorage, it will be restored as initial value", async () => {
+    // Arrange
+    const key = mockNavigation.currentEntry?.key as string;
+    sessionStorage.setItem(`${locationKeyPrefix}${key}`, `{"count":2}`);
+    // Act
+    renderWithUser(<LocationSyncCounterPage />);
+    // Assert
+    await waitFor(() =>
+      expect(screen.getByRole("heading")).toHaveTextContent("count: 2"),
     );
   });
 });
@@ -108,7 +118,6 @@ describe("`useLocationStateValue`/`useLocationSetState` used.", () => {
 
   test("`count` can be updated.", async () => {
     // Arrange
-    mockNavigation.navigate("/count-update");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(await screen.findByRole("button", { name: "increment" }));
@@ -118,7 +127,6 @@ describe("`useLocationStateValue`/`useLocationSetState` used.", () => {
 
   test("`count` is reset at navigation.", async () => {
     // Arrange
-    mockNavigation.navigate("/count-reset");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Act

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -1,4 +1,5 @@
 import {
+  LocationStateDefinition,
   useLocationSetState,
   useLocationState,
   useLocationStateValue,
@@ -20,15 +21,18 @@ beforeEach(() => {
 
 describe("`useLocationState` used.", () => {
   function LocationSyncCounter() {
-    const [counter, setCounter] = useLocationState({
-      name: "counter",
+    const [count, setCount] = useLocationState({
+      name: "count",
       defaultValue: 0,
       storeName: "session",
     });
     return (
       <div>
-        <h1>counter: {counter}</h1>
-        <button onClick={() => setCounter(counter + 1)}>increment</button>
+        <h1>count: {count}</h1>
+        <button onClick={() => setCount(count + 1)}>increment</button>
+        <button onClick={() => setCount((prev) => prev + 1)}>
+          increment with callback
+        </button>
       </div>
     );
   }
@@ -41,45 +45,55 @@ describe("`useLocationState` used.", () => {
     );
   }
 
-  test("`counter` can be updated.", async () => {
+  test("`count` can be updated.", async () => {
     // Arrange
-    mockNavigation.navigate("/counter-update");
+    mockNavigation.navigate("/count-update");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Assert
-    expect(screen.getByRole("heading")).toHaveTextContent("counter: 1");
+    expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
   });
 
-  test("`counter` is reset at navigation.", async () => {
+  test("`count` can be updated with callback.", async () => {
     // Arrange
-    mockNavigation.navigate("/counter-reset");
+    mockNavigation.navigate("/count-update");
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    // Act
+    await user.click(
+      await screen.findByRole("button", { name: "increment with callback" }),
+    );
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
+  });
+
+  test("`count` is reset at navigation.", async () => {
+    // Arrange
+    mockNavigation.navigate("/count-reset");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Act
     mockNavigation.navigate("/anywhere");
     // Assert
     await waitFor(() =>
-      expect(screen.getByRole("heading")).toHaveTextContent("counter: 0"),
+      expect(screen.getByRole("heading")).toHaveTextContent("count: 0"),
     );
   });
 });
 
-describe("`useLocationStateValue`/`useLocationValue` used.", () => {
+describe("`useLocationStateValue`/`useLocationSetState` used.", () => {
   function LocationSyncCounter() {
-    const counter = useLocationStateValue({
+    const counter: LocationStateDefinition<number> = {
       name: "counter",
       defaultValue: 0,
       storeName: "session",
-    });
-    const setCounter = useLocationSetState({
-      name: "counter",
-      storeName: "session",
-    });
+    };
+    const count = useLocationStateValue(counter);
+    const setCount = useLocationSetState(counter);
     return (
       <div>
-        <h1>counter: {counter}</h1>
-        <button onClick={() => setCounter(counter + 1)}>increment</button>
+        <h1>count: {count}</h1>
+        <button onClick={() => setCount(count + 1)}>increment</button>
       </div>
     );
   }
@@ -92,26 +106,26 @@ describe("`useLocationStateValue`/`useLocationValue` used.", () => {
     );
   }
 
-  test("`counter` can be updated.", async () => {
+  test("`count` can be updated.", async () => {
     // Arrange
-    mockNavigation.navigate("/counter-update");
+    mockNavigation.navigate("/count-update");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Assert
-    expect(screen.getByRole("heading")).toHaveTextContent("counter: 1");
+    expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
   });
 
-  test("`counter` is reset at navigation.", async () => {
+  test("`count` is reset at navigation.", async () => {
     // Arrange
-    mockNavigation.navigate("/counter-reset");
+    mockNavigation.navigate("/count-reset");
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Act
     mockNavigation.navigate("/anywhere");
     // Assert
     await waitFor(() =>
-      expect(screen.getByRole("heading")).toHaveTextContent("counter: 0"),
+      expect(screen.getByRole("heading")).toHaveTextContent("count: 0"),
     );
   });
 });

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -92,21 +92,15 @@ describe("using `useLocationState`.", () => {
   });
 });
 
-describe("using `useLocationStateValue`/`useLocationSetState`.", () => {
+describe("using `useLocationStateValue`.", () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
-      name: "counter",
+      name: "count",
       defaultValue: 0,
       storeName: "session",
     };
     const count = useLocationStateValue(counter);
-    const setCount = useLocationSetState(counter);
-    return (
-      <div>
-        <h1>count: {count}</h1>
-        <button onClick={() => setCount(count + 1)}>increment</button>
-      </div>
-    );
+    return <h1>count: {count}</h1>;
   }
 
   function LocationSyncCounterPage() {
@@ -117,24 +111,15 @@ describe("using `useLocationStateValue`/`useLocationSetState`.", () => {
     );
   }
 
-  test("`count` can be updated.", async () => {
+  test("If there is a value in sessionStorage, it will be restored as initial value", async () => {
     // Arrange
-    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    const key = mockNavigation.currentEntry?.key as string;
+    sessionStorage.setItem(`${locationKeyPrefix}${key}`, `{"count":2}`);
     // Act
-    await user.click(await screen.findByRole("button", { name: "increment" }));
-    // Assert
-    expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
-  });
-
-  test("`count` is reset at navigation.", async () => {
-    // Arrange
-    const { user } = renderWithUser(<LocationSyncCounterPage />);
-    await user.click(await screen.findByRole("button", { name: "increment" }));
-    // Act
-    mockNavigation.navigate("/anywhere");
+    renderWithUser(<LocationSyncCounterPage />);
     // Assert
     await waitFor(() =>
-      expect(screen.getByRole("heading")).toHaveTextContent("count: 0"),
+      expect(screen.getByRole("heading")).toHaveTextContent("count: 2"),
     );
   });
 });

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -1,30 +1,12 @@
-import { useLocationState } from "./hooks";
+import {
+  useLocationSetState,
+  useLocationState,
+  useLocationStateValue,
+} from "./hooks";
 import { LocationStateProvider } from "./provider";
 import { createNavigationMock } from "test-utils";
 import { renderWithUser } from "test-utils";
 import { screen, waitFor } from "@testing-library/react";
-
-function LocationSyncCounter() {
-  const [counter, setCounter] = useLocationState({
-    name: "counter",
-    defaultValue: 0,
-    storeName: "session",
-  });
-  return (
-    <div>
-      <h1>counter: {counter}</h1>
-      <button onClick={() => setCounter(counter + 1)}>increment</button>
-    </div>
-  );
-}
-
-function LocationSyncCounterPage() {
-  return (
-    <LocationStateProvider>
-      <LocationSyncCounter />
-    </LocationStateProvider>
-  );
-}
 
 const mockNavigation = createNavigationMock("/");
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -36,25 +18,100 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-test("`counter` can be updated.", async () => {
-  // Arrange
-  mockNavigation.navigate("/counter-update");
-  const { user } = renderWithUser(<LocationSyncCounterPage />);
-  // Act
-  await user.click(await screen.findByRole("button", { name: "increment" }));
-  // Assert
-  expect(screen.getByRole("heading")).toHaveTextContent("counter: 1");
+describe("`useLocationState` used.", () => {
+  function LocationSyncCounter() {
+    const [counter, setCounter] = useLocationState({
+      name: "counter",
+      defaultValue: 0,
+      storeName: "session",
+    });
+    return (
+      <div>
+        <h1>counter: {counter}</h1>
+        <button onClick={() => setCounter(counter + 1)}>increment</button>
+      </div>
+    );
+  }
+
+  function LocationSyncCounterPage() {
+    return (
+      <LocationStateProvider>
+        <LocationSyncCounter />
+      </LocationStateProvider>
+    );
+  }
+
+  test("`counter` can be updated.", async () => {
+    // Arrange
+    mockNavigation.navigate("/counter-update");
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    // Act
+    await user.click(await screen.findByRole("button", { name: "increment" }));
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("counter: 1");
+  });
+
+  test("`counter` is reset at navigation.", async () => {
+    // Arrange
+    mockNavigation.navigate("/counter-reset");
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    await user.click(await screen.findByRole("button", { name: "increment" }));
+    // Act
+    mockNavigation.navigate("/anywhere");
+    // Assert
+    await waitFor(() =>
+      expect(screen.getByRole("heading")).toHaveTextContent("counter: 0"),
+    );
+  });
 });
 
-test("`counter` is reset at navigation.", async () => {
-  // Arrange
-  mockNavigation.navigate("/counter-reset");
-  const { user } = renderWithUser(<LocationSyncCounterPage />);
-  await user.click(await screen.findByRole("button", { name: "increment" }));
-  // Act
-  mockNavigation.navigate("/anywhere");
-  // Assert
-  await waitFor(() =>
-    expect(screen.getByRole("heading")).toHaveTextContent("counter: 0"),
-  );
+describe("`useLocationStateValue`/`useLocationValue` used.", () => {
+  function LocationSyncCounter() {
+    const counter = useLocationStateValue({
+      name: "counter",
+      defaultValue: 0,
+      storeName: "session",
+    });
+    const setCounter = useLocationSetState({
+      name: "counter",
+      storeName: "session",
+    });
+    return (
+      <div>
+        <h1>counter: {counter}</h1>
+        <button onClick={() => setCounter(counter + 1)}>increment</button>
+      </div>
+    );
+  }
+
+  function LocationSyncCounterPage() {
+    return (
+      <LocationStateProvider>
+        <LocationSyncCounter />
+      </LocationStateProvider>
+    );
+  }
+
+  test("`counter` can be updated.", async () => {
+    // Arrange
+    mockNavigation.navigate("/counter-update");
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    // Act
+    await user.click(await screen.findByRole("button", { name: "increment" }));
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("counter: 1");
+  });
+
+  test("`counter` is reset at navigation.", async () => {
+    // Arrange
+    mockNavigation.navigate("/counter-reset");
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    await user.click(await screen.findByRole("button", { name: "increment" }));
+    // Act
+    mockNavigation.navigate("/anywhere");
+    // Assert
+    await waitFor(() =>
+      expect(screen.getByRole("heading")).toHaveTextContent("counter: 0"),
+    );
+  });
 });

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   LocationStateDefinition,
   useLocationSetState,
@@ -20,7 +21,7 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-describe("`useLocationState` used.", () => {
+describe("using `useLocationState`.", () => {
   function LocationSyncCounter() {
     const [count, setCount] = useLocationState({
       name: "count",
@@ -91,7 +92,7 @@ describe("`useLocationState` used.", () => {
   });
 });
 
-describe("`useLocationStateValue`/`useLocationSetState` used.", () => {
+describe("using `useLocationStateValue`/`useLocationSetState`.", () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "counter",
@@ -135,5 +136,44 @@ describe("`useLocationStateValue`/`useLocationSetState` used.", () => {
     await waitFor(() =>
       expect(screen.getByRole("heading")).toHaveTextContent("count: 0"),
     );
+  });
+});
+
+describe("using `useLocationSetState`.", () => {
+  function LocationSyncCounter() {
+    const counter: LocationStateDefinition<number> = {
+      name: "counter",
+      defaultValue: 0,
+      storeName: "session",
+    };
+    const rendered = useRef(1);
+    const setCount = useLocationSetState(counter);
+    useEffect(() => {
+      rendered.current++;
+    }, []);
+
+    return (
+      <div>
+        <h1>rendered: {rendered.current}</h1>
+        <button onClick={() => setCount((prev) => prev + 1)}>increment</button>
+      </div>
+    );
+  }
+
+  function LocationSyncCounterPage() {
+    return (
+      <LocationStateProvider>
+        <LocationSyncCounter />
+      </LocationStateProvider>
+    );
+  }
+
+  test("setCount does not re-render.", async () => {
+    // Arrange
+    const { user } = renderWithUser(<LocationSyncCounterPage />);
+    // Act
+    await user.click(await screen.findByRole("button", { name: "increment" }));
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("rendered: 1");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.47.0)
+      eslint-plugin-react-hooks:
+        specifier: 4.6.0
+        version: 4.6.0(eslint@8.47.0)
       husky:
         specifier: 8.0.3
         version: 8.0.3
@@ -3395,6 +3398,18 @@ packages:
       object.fromentries: 2.0.6
       semver: 6.3.1
     dev: false
+
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.47.0):
+    resolution:
+      {
+        integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.47.0
+    dev: true
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.48.0):
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      zod:
+        specifier: 3.22.2
+        version: 3.22.2
 
   packages/configs: {}
 
@@ -7435,3 +7438,10 @@ packages:
       {
         integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==,
       }
+
+  /zod@3.22.2:
+    resolution:
+      {
+        integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==,
+      }
+    dev: false


### PR DESCRIPTION
- `useLocationStateValue`
- `useLocationStateValue`
- `refine` option
  - examplesにzodを用いた実装を追加しました
- `useLocationStateSnapshot`はどう実装したものかまだイメージついてないので、後続作業にしようと思ってます
- Serialize/Deserializeも別PRにしようと思います