### PR TITLE
add launch.json for VSC and support for sourcemap

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "apps/example-next - dev",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "cwd": "${workspaceFolder}/apps/example-next",
+      "skipFiles": ["<node_internals>/**"],
+      "outFiles": ["${workspaceFolder}/**/*.js"],
+      "sourceMaps": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/apps/example-next/**",
+        "!**/node_modules/**"
+      ]
+    },
+    {
+      "name": "apps/example-next - start",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["start"],
+      "cwd": "${workspaceFolder}/apps/example-next",
+      "skipFiles": ["<node_internals>/**"],
+      "outFiles": ["${workspaceFolder}/**/*.js"],
+      "sourceMaps": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/apps/example-next/.next/server/**/*.js.map",
+        "!**/node_modules/**"
+      ]
+    }
+  ]
+}

--- a/apps/example-next/next.config.js
+++ b/apps/example-next/next.config.js
@@ -3,6 +3,14 @@ const nextConfig = {
   experimental: {
     scrollRestoration: true,
   },
+
+  productionBrowserSourceMaps: true,
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.devtool = "source-map";
+    }
+    return config;
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
VSCodeから`apps/example-next`を起動するための`launch.json`を追加しました
`next start`でもデバッガが使えるように`next.config.js`にソースマップの生成を追加しました