### PR TITLE
fix: Undefined crypto.randomUUID on Firefox.

### DIFF
--- a/packages/location-state-core/src/unsafe-navigation.ts
+++ b/packages/location-state-core/src/unsafe-navigation.ts
@@ -7,11 +7,17 @@ export const unsafeNavigation =
     ? window.navigation
     : installUnsafeNavigation();
 
+function randomUUID() {
+  return typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+}
+
 function installUnsafeNavigation(): Navigation {
   const originalHistory = window.history;
   if (!originalHistory.state) {
     originalHistory.replaceState(
-      { ___UNSAFE_NAVIGATION_KEY___: crypto.randomUUID() },
+      { ___UNSAFE_NAVIGATION_KEY___: randomUUID() },
       "",
       location.href,
     );
@@ -19,7 +25,7 @@ function installUnsafeNavigation(): Navigation {
 
   const pushState: History["pushState"] = (state, unused, url) => {
     originalHistory.pushState(
-      { ___UNSAFE_NAVIGATION_KEY___: crypto.randomUUID(), ...state },
+      { ___UNSAFE_NAVIGATION_KEY___: randomUUID(), ...state },
       unused,
       url,
     );
@@ -133,7 +139,7 @@ function installUnsafeNavigation(): Navigation {
     get: () => {
       const { ___UNSAFE_NAVIGATION_KEY___ } = originalHistory.state ?? {};
       return {
-        key: ___UNSAFE_NAVIGATION_KEY___ ?? crypto.randomUUID(),
+        key: ___UNSAFE_NAVIGATION_KEY___ ?? randomUUID(),
       };
     },
   });


### PR DESCRIPTION
- Mac firefoxでcrypto.randomUUIDが未定義だったので分岐しました
  - しかし[zodの正規表現起因でエラー](https://github.com/colinhacks/zod/issues/2302)となり
  - zodを抜いたらロード時のエラーはなくなり、ただボタンやチェックボックス押下でクラッシュするようになりました。
  - 現状なぜクラッシュするのか、どう対応すればいいか不明なので上記分岐のみまず追加するか、対応方法検討してからPRマージするか悩んでいます。

<img width="644" alt="スクリーンショット 2023-09-22 21 36 36" src="https://github.com/recruit-tech/location-state/assets/25711332/25fd5eb6-0156-44d4-9f9b-f5a89c70aa45">
<img width="1392" alt="スクリーンショット 2023-09-22 21 36 57" src="https://github.com/recruit-tech/location-state/assets/25711332/210cd7e4-7660-4804-b11c-dec8c623e3d3">
