### PR TITLE
fix playwrigt ci, add prettierignore

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install packages
         run: pnpm i --ignore-scripts
       - name: Install playwright browsers
-        run: pnpm dlx playwright install --with-deps
+        run: pnpm exec playwright install --with-deps
       - name: Build project
         run: pnpm build
       - name: Run integration-test

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 dist
 types
 pnpm-lock.yaml
+playwright-report


### PR DESCRIPTION
playwrightのCIがpnpm dlx起因で落ちるようになってしまったので修正しました。
またprettierのignore対象にplaywright-reportを追加しました。

## ref

https://github.com/recruit-tech/location-state/actions/runs/6496795396/job/17645096426?pr=44
https://github.com/microsoft/playwright/issues/19562