### PR TITLE
commit hook biome format to check

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,css,json,cjs,mjs}": "biome format --write"
+    "*.{js,jsx,ts,tsx,css,json,cjs,mjs}": "biome check --apply"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.3",


### PR DESCRIPTION
importの並び順は`biome format`では適用されず、不便だったので修正しました。
速度的にはかなり高速なので遜色ないと思います