### PR TITLE
fix changesets confri:  fixed added `@location-state/conform`, `onlyUpdatePeerDependentsWhenOutOfRange ` enabled

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,10 +2,15 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@location-state/core", "@location-state/next"]],
+  "fixed": [
+    ["@location-state/core", "@location-state/next", "@location-state/conform"]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["example-*"]
+  "ignore": ["example-*"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
`@location-state/conform`のバージョンと他パッケージのバージョンが同期するよう設定を見直しました。
また、`@location-state/conform`で設定したpeerがあることによってmajor update判定されてしまっていたので、下記オプションを有効にしました。
https://github.com/changesets/changesets/blob/0bf89b3709e3e3df6ed5dbb8ece0fb000a55d5f4/docs/experimental-options.md#onlyupdatepeerdependentswhenoutofrange-type-boolean

`pnpm changeset status`でminorとなることを確認済みです。