### PR TITLE
chore: ignore package.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,7 @@
       "**/tsconfig.*.json",
       "**/node_modules",
       "**/.next",
+      "**/package.json",
       "**/types/**",
       "**/test-results/**",
       "**/dist/**",


### PR DESCRIPTION
changesetsが行うリリースPRで`package.json`を更新しますが、この更新に対するフォーマットルールのオプションがぱっと見見当たりませんでした。
https://github.com/changesets/action
取り急ぎbiomeのルールと競合するので、`package.json`のformatを無視するようにします。