### PR TITLE
chore: add renovate group to `conform`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "dependencyDashboard": false,
   "automerge": true,
   "platformAutomerge": true,
-  "separateMultipleMajor": true
+  "separateMultipleMajor": true,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@conform-to/"],
+      "groupName": "conform packages"
+    }
+  ]
 }


### PR DESCRIPTION
confromは同時にアップデートする必要があるので設定を追加しました。
同時アップデート必須なオプションは見つけられなかったですが、実際はconfromは同時リリースなので問題ないはずだと思います。