### PR TITLE
fix(deps): move `@repo/utils` from dependencies to devDependencies

### DIFF
--- a/packages/location-state-conform/package.json
+++ b/packages/location-state-conform/package.json
@@ -29,7 +29,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@repo/utils": "workspace:*",
     "valibot": "0.33.3"
   },
   "devDependencies": {
@@ -37,6 +36,7 @@
     "@location-state/core": "workspace:*",
     "@repo/configs": "workspace:*",
     "@repo/test-utils": "workspace:*",
+    "@repo/utils": "workspace:*",
     "@types/react": "18.3.3",
     "react": "18.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ importers:
 
   packages/location-state-conform:
     dependencies:
-      '@repo/utils':
-        specifier: workspace:*
-        version: link:../utils
       valibot:
         specifier: 0.33.3
         version: 0.33.3
@@ -220,6 +217,9 @@ importers:
       '@repo/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3


### PR DESCRIPTION
i am getting below error when i try to install the package

```sh
npm i @location-state/conform
npm notice
npm notice New minor version of npm available! 10.7.0 -> 10.8.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.8.1
npm notice To update run: npm install -g npm@10.8.1
npm notice
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@repo%2futils - Not found
npm error 404
npm error 404  '@repo/utils@0.0.0' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

so, i moved `@repo/utils` from dependencies to devDependencies