### PR TITLE
fix(store): Improve Store's initial `load()` behavior to merge state when loading with existing state.

### DIFF
--- a/.changeset/happy-baths-stop.md
+++ b/.changeset/happy-baths-stop.md
@@ -2,4 +2,4 @@
 "@location-state/core": minor
 ---
 
-Improve Store's initial `load()` behavior to merge state when loading with existing state.
+Fixed an issue where state was being discarded even when the user attempted to save it using `useEffect` on initial render.

--- a/.changeset/happy-baths-stop.md
+++ b/.changeset/happy-baths-stop.md
@@ -1,0 +1,5 @@
+---
+"@location-state/core": minor
+---
+
+Improve Store's initial `load()` behavior to merge state when loading with existing state.

--- a/apps/example-next-basic/playwright/save-on-use-effect.spec.ts
+++ b/apps/example-next-basic/playwright/save-on-use-effect.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("restore random id that save on `useEffect()`", async ({ page }) => {
+  // Navigate to the target page.
+  await page.goto("http://localhost:3000/pages/save-on-use-effect");
+  const h1Element = page.getByRole("heading", { level: 1 });
+  const initialH1Text = await h1Element.textContent();
+  await expect(initialH1Text).not.toBeNull();
+  await expect(h1Element).toHaveText(
+    /Save on `useEffect\(\)`, random value: \d+/,
+  );
+  // Navigate to the top page.
+  await page.getByRole("link", { name: /^\/pages$/ }).click();
+  await expect(page).toHaveURL("http://localhost:3000/pages");
+  // Navigate back to the target page.
+  await page.goBack();
+  await expect(page).toHaveURL(
+    "http://localhost:3000/pages/save-on-use-effect",
+  );
+  await expect(
+    await page.getByRole("heading", { level: 1 }).textContent(),
+  ).toBe(initialH1Text);
+});

--- a/apps/example-next-basic/src/pages/pages/index.tsx
+++ b/apps/example-next-basic/src/pages/pages/index.tsx
@@ -16,6 +16,11 @@ export default function Page() {
         <li>
           <Link href="/pages/ssg/1">/pages/ssg/1</Link>
         </li>
+        <li>
+          <Link href="/pages/save-on-use-effect">
+            /pages/save-on-use-effect
+          </Link>
+        </li>
       </ul>
       <Counter storeName="session" />
       <Counter storeName="url" />

--- a/apps/example-next-basic/src/pages/pages/save-on-use-effect/index.tsx
+++ b/apps/example-next-basic/src/pages/pages/save-on-use-effect/index.tsx
@@ -1,0 +1,48 @@
+import { useLocationState } from "@location-state/core";
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useEffect } from "react";
+
+type Props = {
+  id: number;
+};
+
+export default function Page({ id }: Props) {
+  const [randomValue, setRandomValue] = useLocationState<null | number>({
+    name: "randomValue",
+    defaultValue: null,
+    storeName: "session",
+  });
+
+  useEffect(() => {
+    if (randomValue === null) {
+      setRandomValue(id);
+      console.debug("set randomValue: ", id);
+    }
+  }, [randomValue, setRandomValue, id]);
+
+  return (
+    <div>
+      <h1>Save on `useEffect()`, random value: {randomValue}</h1>
+      <ul>
+        <li>
+          <Link href="/pages">/pages</Link>
+        </li>
+        <li>
+          <Link href="/pages/other">/pages/other</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { id: string }
+> = async () => {
+  return {
+    props: {
+      id: Math.floor(Math.random() * 100),
+    },
+  };
+};

--- a/packages/location-state-core/src/stores/in-memory-store.test.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.test.ts
@@ -90,6 +90,7 @@ test("The slice is merged when `load` is called after `set`.", () => {
   store.load("initial");
   // Assert
   expect(store.get("foo")).toBe(0);
+  expect(store.get("bar")).toBeUndefined();
 });
 
 test("The slice is reset when `load` is called with different key.", () => {

--- a/packages/location-state-core/src/stores/in-memory-store.test.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.test.ts
@@ -73,7 +73,26 @@ test("The listener is unsubscribed by the returned callback, it will no longer b
   expect(listener).toBeCalledTimes(0);
 });
 
-test("The slice is reset when `load` is called and the key is updated.", () => {
+test("The slice is undefined when `load` is called without `set`.", () => {
+  // Arrange
+  const store = new InMemoryStore();
+  // Act
+  store.load("initial");
+  // Assert
+  expect(store.get("foo")).toBeUndefined();
+});
+
+test("The slice is merged when `load` is called after `set`.", () => {
+  // Arrange
+  const store = new InMemoryStore();
+  store.set("foo", 0);
+  // Act
+  store.load("initial");
+  // Assert
+  expect(store.get("foo")).toBe(0);
+});
+
+test("The slice is reset when `load` is called with different key.", () => {
   // Arrange
   const store = new InMemoryStore();
   store.load("initial");

--- a/packages/location-state-core/src/stores/in-memory-store.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.ts
@@ -30,7 +30,7 @@ export class InMemoryStore implements Store {
 
   load(locationKey: string) {
     if (this.currentKey === locationKey) return;
-    const storageState = this.storage.get(locationKey);
+    const storageState = this.storage.get(locationKey) ?? {};
     // Initial key is `null`, so we need to merge the state with the existing state.
     // Because it may be set before load.
     if (this.currentKey === null) {
@@ -39,7 +39,7 @@ export class InMemoryStore implements Store {
         ...this.state,
       };
     } else {
-      this.state = storageState ?? {};
+      this.state = storageState;
     }
     this.currentKey = locationKey;
     this.events.deferEmitAll();

--- a/packages/location-state-core/src/stores/in-memory-store.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.ts
@@ -30,8 +30,18 @@ export class InMemoryStore implements Store {
 
   load(locationKey: string) {
     if (this.currentKey === locationKey) return;
+    const storageState = this.storage.get(locationKey);
+    // Initial key is `null`, so we need to merge the state with the existing state.
+    // Because it may be set before load.
+    if (this.currentKey === null) {
+      this.state = {
+        ...storageState,
+        ...this.state,
+      };
+    } else {
+      this.state = storageState ?? {};
+    }
     this.currentKey = locationKey;
-    this.state = this.storage.get(locationKey) ?? {};
     this.events.deferEmitAll();
   }
 

--- a/packages/location-state-core/src/stores/storage-store.test.ts
+++ b/packages/location-state-core/src/stores/storage-store.test.ts
@@ -110,6 +110,31 @@ test("On `load` called, if the value of the corresponding key is in Storage, the
   );
 });
 
+test("On `load` called after `set`, the value of the slice is merged with the value in storage.", () => {
+  // Arrange
+  storageMock.getItem.mockReturnValueOnce(
+    JSON.stringify({ foo: "storage value" }),
+  );
+  const store = new StorageStore(storage);
+  store.set("bar", "updated");
+  // Act
+  store.load("current_location");
+  // Assert
+  expect(store.get("foo")).toBe("storage value");
+  expect(store.get("bar")).toBe("updated");
+});
+
+test("On `load` called twice with different key after `set`, the value of the slice is reset.", () => {
+  // Arrange
+  const store = new StorageStore(storage);
+  store.set("bar", "updated");
+  store.load("current_location");
+  // Act
+  store.load("other_location");
+  // Assert
+  expect(store.get("bar")).toBeUndefined();
+});
+
 test("On `load` called with serializer, if the value of the corresponding key is in Storage, then slice is evaluated by deserialize.", () => {
   // Arrange
   const navigationKey = "current_location";

--- a/packages/location-state-core/src/stores/storage-store.test.ts
+++ b/packages/location-state-core/src/stores/storage-store.test.ts
@@ -113,15 +113,20 @@ test("On `load` called, if the value of the corresponding key is in Storage, the
 test("On `load` called after `set`, the value of the slice is merged with the value in storage.", () => {
   // Arrange
   storageMock.getItem.mockReturnValueOnce(
-    JSON.stringify({ foo: "storage value" }),
+    JSON.stringify({
+      foo: "storage foo",
+      bar: "storage bar",
+    }),
   );
   const store = new StorageStore(storage);
-  store.set("bar", "updated");
+  store.set("bar", "updated bar");
+  store.set("baz", "updated baz");
   // Act
   store.load("current_location");
   // Assert
-  expect(store.get("foo")).toBe("storage value");
-  expect(store.get("bar")).toBe("updated");
+  expect(store.get("foo")).toBe("storage foo");
+  expect(store.get("bar")).toBe("updated bar");
+  expect(store.get("baz")).toBe("updated baz");
 });
 
 test("On `load` called twice with different key after `set`, the value of the slice is reset.", () => {

--- a/packages/location-state-core/src/stores/storage-store.ts
+++ b/packages/location-state-core/src/stores/storage-store.ts
@@ -35,7 +35,8 @@ export class StorageStore implements Store {
   load(locationKey: string) {
     if (this.currentKey === locationKey) return;
     try {
-      const value = this.storage?.getItem(storageKey(locationKey)) ?? null;
+      const value =
+        this.storage?.getItem(formatStorageKey(locationKey)) ?? null;
       const state =
         value !== null ? this.stateSerializer.deserialize(value) : {};
       // Initial key is `null`, so we need to merge the state with the existing state.
@@ -61,7 +62,7 @@ export class StorageStore implements Store {
       return;
     }
     if (Object.keys(this.state).length === 0) {
-      this.storage?.removeItem(storageKey(this.currentKey));
+      this.storage?.removeItem(formatStorageKey(this.currentKey));
       return;
     }
     let value: string;
@@ -71,10 +72,10 @@ export class StorageStore implements Store {
       console.error(e);
       return;
     }
-    this.storage?.setItem(storageKey(this.currentKey), value);
+    this.storage?.setItem(formatStorageKey(this.currentKey), value);
   }
 }
 
-function storageKey(key: string) {
+function formatStorageKey(key: string) {
   return `${locationKeyPrefix}${key}`;
 }

--- a/packages/location-state-core/src/stores/storage-store.ts
+++ b/packages/location-state-core/src/stores/storage-store.ts
@@ -35,8 +35,7 @@ export class StorageStore implements Store {
   load(locationKey: string) {
     if (this.currentKey === locationKey) return;
     try {
-      const value =
-        this.storage?.getItem(formatStorageKey(locationKey)) ?? null;
+      const value = this.storage?.getItem(toStorageKey(locationKey)) ?? null;
       const state =
         value !== null ? this.stateSerializer.deserialize(value) : {};
       // Initial key is `null`, so we need to merge the state with the existing state.
@@ -62,7 +61,7 @@ export class StorageStore implements Store {
       return;
     }
     if (Object.keys(this.state).length === 0) {
-      this.storage?.removeItem(formatStorageKey(this.currentKey));
+      this.storage?.removeItem(toStorageKey(this.currentKey));
       return;
     }
     let value: string;
@@ -72,10 +71,10 @@ export class StorageStore implements Store {
       console.error(e);
       return;
     }
-    this.storage?.setItem(formatStorageKey(this.currentKey), value);
+    this.storage?.setItem(toStorageKey(this.currentKey), value);
   }
 }
 
-function formatStorageKey(key: string) {
+function toStorageKey(key: string) {
   return `${locationKeyPrefix}${key}`;
 }


### PR DESCRIPTION
Storeの`load()`が呼ばれる前に`set()`された場合に値が破棄されてしまっていたので、初期値にマージするよう修正しました。
僕の環境でexampleを書き換えて動作検証済みです。

- mainブランチで値が破棄されてることを確認
- `useEffect(() => setCounter(999))`を`<Counter>`に追加前後の挙動を観察
- StorageとInMemoryでそれぞれで↑を検証