### PR TITLE
refactor: test structure

### DIFF
--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -22,7 +22,7 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-describe("using `useLocationState`.", () => {
+describe("`useLocationState`", () => {
   function LocationSyncCounter() {
     const [count, setCount] = useLocationState({
       name: "count",
@@ -50,7 +50,7 @@ describe("using `useLocationState`.", () => {
     );
   }
 
-  test("`count` can be updated.", async () => {
+  test("The `count` can be updated.", async () => {
     // Arrange
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
@@ -59,7 +59,7 @@ describe("using `useLocationState`.", () => {
     expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
   });
 
-  test("`count` can be updated with updater.", async () => {
+  test("The `count` can be updated with updater.", async () => {
     // Arrange
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
@@ -70,7 +70,7 @@ describe("using `useLocationState`.", () => {
     expect(screen.getByRole("heading")).toHaveTextContent("count: 1");
   });
 
-  test("`count` is reset at navigation.", async () => {
+  test("The `count` is reset at navigation.", async () => {
     // Arrange
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     await user.click(await screen.findByRole("button", { name: "increment" }));
@@ -82,7 +82,7 @@ describe("using `useLocationState`.", () => {
     );
   });
 
-  test("If there is a value in sessionStorage, it will be restored as initial value.", async () => {
+  test("If there is a value in `sessionStorage`, it will be restored as the initial value.", async () => {
     // Arrange
     const key = mockNavigation.currentEntry?.key as string;
     sessionStorage.setItem(`${locationKeyPrefix}${key}`, `{"count":2}`);
@@ -95,7 +95,7 @@ describe("using `useLocationState`.", () => {
   });
 });
 
-describe("using `useLocationStateValue`.", () => {
+describe("`useLocationStateValue`", () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "count",
@@ -114,7 +114,7 @@ describe("using `useLocationStateValue`.", () => {
     );
   }
 
-  test("If there is a value in sessionStorage, it will be restored as initial value.", async () => {
+  test("If there is a value in `sessionStorage`, it will be restored as the initial value.", async () => {
     // Arrange
     const key = mockNavigation.currentEntry?.key as string;
     sessionStorage.setItem(`${locationKeyPrefix}${key}`, `{"count":2}`);
@@ -125,11 +125,9 @@ describe("using `useLocationStateValue`.", () => {
       expect(screen.getByRole("heading")).toHaveTextContent("count: 2"),
     );
   });
-
-  test.todo(`When store's value is changed, component is re-rendered.`);
 });
 
-describe("using `useLocationSetState`.", () => {
+describe("`useLocationSetState`", () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "counter",
@@ -160,18 +158,17 @@ describe("using `useLocationSetState`.", () => {
     );
   }
 
-  test("setCount does not re-render.", async () => {
+  test("`setCount` does not re-render.", async () => {
     // Arrange
     const { user } = renderWithUser(<LocationSyncCounterPage />);
     // Act
     await user.click(await screen.findByRole("button", { name: "increment" }));
     // Assert
     expect(screen.getByRole("heading")).toHaveTextContent("rendered: 1");
-    // todo: assert store's value updated.
   });
 });
 
-describe("using `useLocationGetState` with `storeName`.", () => {
+describe("`useLocationGetState`", () => {
   function LocationSyncOnceCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "count",

--- a/packages/location-state-core/src/location-sync.test.tsx
+++ b/packages/location-state-core/src/location-sync.test.tsx
@@ -22,7 +22,7 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-describe("`useLocationState`", () => {
+describe(useLocationState, () => {
   function LocationSyncCounter() {
     const [count, setCount] = useLocationState({
       name: "count",
@@ -95,7 +95,7 @@ describe("`useLocationState`", () => {
   });
 });
 
-describe("`useLocationStateValue`", () => {
+describe(useLocationStateValue, () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "count",
@@ -127,7 +127,7 @@ describe("`useLocationStateValue`", () => {
   });
 });
 
-describe("`useLocationSetState`", () => {
+describe(useLocationSetState, () => {
   function LocationSyncCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "counter",
@@ -168,7 +168,7 @@ describe("`useLocationSetState`", () => {
   });
 });
 
-describe("`useLocationGetState`", () => {
+describe(useLocationGetState, () => {
   function LocationSyncOnceCounter() {
     const counter: LocationStateDefinition<number> = {
       name: "count",

--- a/packages/location-state-core/src/stores/in-memory-store.test.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.test.ts
@@ -1,135 +1,142 @@
 import { expect, test, vi } from "vitest";
 import { InMemoryStore } from "./in-memory-store";
 
-test("The initial value is undefined.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  // Act
-  const slice = store.get("foo");
-  // Assert
-  expect(slice).toBeUndefined();
-});
-
-test("After updating a slice, the updated value can be obtained.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  // Act
-  store.set("foo", "updated");
-  // Assert
-  expect(store.get("foo")).toBe("updated");
-});
-
-test("listener is called when updating slice.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  const listener = vi.fn();
-  store.subscribe("foo", listener);
-  // Act
-  store.set("foo", "updated");
-  // Assert
-  expect(listener).toBeCalledTimes(1);
-});
-
-test("listener is called even if updated with undefined.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  store.set("foo", "updated");
-  const listener = vi.fn();
-  store.subscribe("foo", listener);
-  // Act
-  store.set("foo", undefined);
-  // Assert
-  expect(listener).toBeCalledTimes(1);
-});
-
-test("store.get in the listener to get the latest value.", () => {
-  // Arrange
-  expect.assertions(4);
-  const store = new InMemoryStore();
-  const listener1 = vi.fn(() => {
-    expect(store.get("foo")).toBe("updated");
+describe("InMemoryStore", () => {
+  test("The initial value is undefined.", () => {
+    // Arrange
+    const store = new InMemoryStore();
+    // Act
+    const slice = store.get("foo");
+    // Assert
+    expect(slice).toBeUndefined();
   });
-  const listener2 = vi.fn(() => {
-    expect(store.get("foo")).toBe("updated");
+
+  describe("on `set`", () => {
+    test("The updated value can be obtained.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      // Act
+      store.set("foo", "updated");
+      // Assert
+      expect(store.get("foo")).toBe("updated");
+    });
+
+    test("The listener is called.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      const listener = vi.fn();
+      store.subscribe("foo", listener);
+      // Act
+      store.set("foo", "updated");
+      // Assert
+      expect(listener).toBeCalledTimes(1);
+    });
+
+    test("`set` with `undefined` is also called the listener.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      store.set("foo", "updated");
+      const listener = vi.fn();
+      store.subscribe("foo", listener);
+      // Act
+      store.set("foo", undefined);
+      // Assert
+      expect(listener).toBeCalledTimes(1);
+    });
+
+    test("The listener can get the latest value by calling `store.get`.", () => {
+      // Arrange
+      expect.assertions(4);
+      const store = new InMemoryStore();
+      const listener1 = vi.fn(() => {
+        expect(store.get("foo")).toBe("updated");
+      });
+      const listener2 = vi.fn(() => {
+        expect(store.get("foo")).toBe("updated");
+      });
+      store.subscribe("foo", listener1);
+      store.subscribe("foo", listener2);
+      // Act
+      store.set("foo", "updated");
+      // Assert
+      expect(listener1).toBeCalledTimes(1);
+      expect(listener2).toBeCalledTimes(1);
+    });
+
+    test("The listener is unsubscribed, it will no longer be called when the slice is updated.", () => {
+      expect.assertions(1);
+      // Arrange
+      const store = new InMemoryStore();
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe("foo", listener);
+      // Act
+      unsubscribe();
+      store.set("foo", "updated");
+      // Assert
+      expect(listener).toBeCalledTimes(0);
+    });
   });
-  store.subscribe("foo", listener1);
-  store.subscribe("foo", listener2);
-  // Act
-  store.set("foo", "updated");
-  // Assert
-  expect(listener1).toBeCalledTimes(1);
-  expect(listener2).toBeCalledTimes(1);
-});
 
-test("The listener is unsubscribed by the returned callback, it will no longer be called when the slice is updated.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  const listener = vi.fn();
-  const unsubscribe = store.subscribe("foo", listener);
-  // Act
-  unsubscribe();
-  store.set("foo", "updated");
-  // Assert
-  expect(listener).toBeCalledTimes(0);
-});
+  describe("on `load`", () => {
+    test("`load` without `set` is undefined.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      // Act
+      store.load("initial");
+      // Assert
+      expect(store.get("foo")).toBeUndefined();
+    });
 
-test("The slice is undefined when `load` is called without `set`.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  // Act
-  store.load("initial");
-  // Assert
-  expect(store.get("foo")).toBeUndefined();
-});
+    test("`load` after `set` is merged.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      store.set("foo", 0);
+      // Act
+      store.load("initial");
+      // Assert
+      expect(store.get("foo")).toBe(0);
+      expect(store.get("bar")).toBeUndefined();
+    });
 
-test("The slice is merged when `load` is called after `set`.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  store.set("foo", 0);
-  // Act
-  store.load("initial");
-  // Assert
-  expect(store.get("foo")).toBe(0);
-  expect(store.get("bar")).toBeUndefined();
-});
+    test("`load` with different key is reset.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      store.load("initial");
+      store.set("foo", "updated");
+      // Act
+      store.load("second");
+      // Assert
+      expect(store.get("foo")).toBeUndefined();
+    });
 
-test("The slice is reset when `load` is called with different key.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  store.load("initial");
-  store.set("foo", "updated");
-  // Act
-  store.load("second");
-  // Assert
-  expect(store.get("foo")).toBeUndefined();
-});
+    test("The key is restored, the slice is also restored.", () => {
+      // Arrange
+      const store = new InMemoryStore();
+      store.load("initial");
+      store.set("foo", "updated initial");
+      store.save();
+      store.load("second");
+      store.set("foo", "updated second");
+      // Act
+      store.load("initial");
+      // Assert
+      expect(store.get("foo")).toBe("updated initial");
+    });
 
-test("When the key is restored, the slice value is also restored.", () => {
-  // Arrange
-  const store = new InMemoryStore();
-  store.load("initial");
-  store.set("foo", "updated initial");
-  store.save();
-  store.load("second");
-  store.set("foo", "updated second");
-  // Act
-  store.load("initial");
-  // Assert
-  expect(store.get("foo")).toBe("updated initial");
-});
-
-test("On `load` called, all listener notified.", async () => {
-  // Arrange
-  const store = new InMemoryStore();
-  const listener1 = vi.fn();
-  const listener2 = vi.fn();
-  store.subscribe("foo", listener1);
-  store.subscribe("foo", listener2);
-  // Act
-  store.load("initial");
-  // Generate and execute microtasks with Promise to wait for listener execution.
-  await Promise.resolve();
-  // Assert
-  expect(listener1).toBeCalledTimes(1);
-  expect(listener2).toBeCalledTimes(1);
+    test("`load` is called, all listener notified.", async () => {
+      // Arrange
+      const store = new InMemoryStore();
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      store.subscribe("foo", listener1);
+      store.subscribe("foo", listener2);
+      // Act
+      store.load("initial");
+      // Generate and execute microtasks with Promise to wait for listener execution.
+      await Promise.resolve();
+      // Assert
+      expect(listener1).toBeCalledTimes(1);
+      expect(listener2).toBeCalledTimes(1);
+    });
+  });
 });

--- a/packages/location-state-core/src/stores/in-memory-store.test.ts
+++ b/packages/location-state-core/src/stores/in-memory-store.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { InMemoryStore } from "./in-memory-store";
 
-describe("InMemoryStore", () => {
+describe(InMemoryStore, () => {
   test("The initial value is undefined.", () => {
     // Arrange
     const store = new InMemoryStore();
@@ -11,7 +11,7 @@ describe("InMemoryStore", () => {
     expect(slice).toBeUndefined();
   });
 
-  describe("on `set`", () => {
+  describe(InMemoryStore.prototype.set, () => {
     test("The updated value can be obtained.", () => {
       // Arrange
       const store = new InMemoryStore();
@@ -77,7 +77,7 @@ describe("InMemoryStore", () => {
     });
   });
 
-  describe("on `load`", () => {
+  describe(InMemoryStore.prototype.load, () => {
     test("`load` without `set` is undefined.", () => {
       // Arrange
       const store = new InMemoryStore();

--- a/packages/location-state-core/src/stores/storage-store.test.ts
+++ b/packages/location-state-core/src/stores/storage-store.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("StoreStorage", () => {
+describe(StorageStore, () => {
   describe("`constructor` format", () => {
     describe("Recommended", () => {
       test("`sessionStorage` is used when arguments are omitted", () => {
@@ -180,7 +180,7 @@ describe("StoreStorage", () => {
       expect(slice).toBeUndefined();
     });
 
-    describe("On `set`", () => {
+    describe(StorageStore.prototype.set, () => {
       test("The updated value is obtained.", () => {
         // Arrange
         const store = new StorageStore({ storage });
@@ -250,7 +250,7 @@ describe("StoreStorage", () => {
       });
     });
 
-    describe("On `load`", () => {
+    describe(StorageStore.prototype.load, () => {
       test("The slice is the value in storage.", () => {
         // Arrange
         const navigationKey = "current_location";
@@ -316,7 +316,7 @@ describe("StoreStorage", () => {
       });
     });
 
-    describe("On `save`", () => {
+    describe(StorageStore.prototype.save, () => {
       test("The state is saved in Storage.", () => {
         // Arrange
         const currentLocationKey = "current_location";
@@ -347,7 +347,7 @@ describe("StoreStorage", () => {
   });
 
   describe("`storage` and `stateSerializer` are provided", () => {
-    describe("On `load`", () => {
+    describe(StorageStore.prototype.load, () => {
       test("The value of the slice is evaluated by `deserialize`.", () => {
         // Arrange
         const navigationKey = "current_location";
@@ -396,7 +396,7 @@ describe("StoreStorage", () => {
       });
     });
 
-    describe("On `save`", () => {
+    describe(StorageStore.prototype.save, () => {
       test("The state is saved in Storage with evaluated by `serialize`.", () => {
         // Arrange
         const currentLocationKey = "current_location";

--- a/packages/location-state-core/src/stores/storage-store.test.ts
+++ b/packages/location-state-core/src/stores/storage-store.test.ts
@@ -232,7 +232,7 @@ describe("StoreStorage", () => {
         expect(listener2).toBeCalledTimes(1);
       });
 
-      test("The listener is unsubscribed by the returned callback, it will no longer be called when updating.", () => {
+      test("The listener is unsubscribed, it will no longer be called when updating.", () => {
         // Arrange
         const store = new StorageStore({ storage });
         const listeners = {

--- a/packages/location-state-core/src/stores/url-store.test.ts
+++ b/packages/location-state-core/src/stores/url-store.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
   vi.clearAllTimers();
 });
 
-describe("`URLStore`", () => {
+describe(URLStore, () => {
   function prepareLocation({
     pathname,
     search = "",
@@ -56,7 +56,7 @@ describe("`URLStore`", () => {
       expect(value).toBeUndefined();
     });
 
-    describe("on `set`", () => {
+    describe(URLStore.prototype.set, () => {
       test("The store's values are updated and reflected in the URL.", () => {
         // Arrange
         prepareLocation({
@@ -140,7 +140,7 @@ describe("`URLStore`", () => {
       });
     });
 
-    describe("on `load`", () => {
+    describe(URLStore.prototype.load, () => {
       test("The state is loaded from url.", () => {
         // Arrange
         prepareLocation({
@@ -244,7 +244,7 @@ describe("`URLStore`", () => {
   });
 });
 
-describe("`searchParamEncoder`", () => {
+describe(searchParamEncoder, () => {
   describe("with default serializer", () => {
     const encoder = searchParamEncoder("location-state", jsonSerializer);
 

--- a/packages/location-state-core/src/stores/utils/create-throttle.test.ts
+++ b/packages/location-state-core/src/stores/utils/create-throttle.test.ts
@@ -51,7 +51,7 @@ function mapExecutedIntervalTimes(callback: Mock) {
   return callback.mock.results.map((result) => result.value);
 }
 
-test("Throttle function is first called, it is calling back immediately.", () => {
+test("The throttle function is first called, it is calling back immediately.", () => {
   // Arrange
   const throttle = createThrottle();
   const callback = vi.fn();
@@ -61,7 +61,7 @@ test("Throttle function is first called, it is calling back immediately.", () =>
   expect(callback).toBeCalledTimes(1);
 });
 
-describe("Throttle function is called at 10ms interval.", () => {
+describe("10ms interval.", () => {
   test.each<IntervalTestParameter>([
     {
       callUntil: 10,
@@ -96,7 +96,7 @@ describe("Throttle function is called at 10ms interval.", () => {
       executedTimes: [0, 50, 150, 350, 850, 1850, 2850, 3850, 4850, 5850],
     },
   ])(
-    "Throttle function called until $callUntil ms, it will be executed $executedTimes .",
+    "The throttle function called until $callUntil ms, it will be executed $executedTimes .",
     ({ callUntil, executedTimes }) => {
       // Arrange
       const throttle = createThrottle();
@@ -130,7 +130,7 @@ describe("Throttle function is called at 10ms interval.", () => {
       terminatedAt: 1850,
     },
   ])(
-    "Throttle function called until $callUntil, the throttle will terminate in $terminatedAt ms.",
+    "The throttle function called until $callUntil, the throttle will terminate in $terminatedAt ms.",
     ({ callUntil, terminatedAt }) => {
       // Arrange
       const throttle = createThrottle();
@@ -147,7 +147,7 @@ describe("Throttle function is called at 10ms interval.", () => {
   );
 });
 
-describe("Throttle function called at 50ms interval.", () => {
+describe("50ms interval.", () => {
   test.each<IntervalTestParameter>([
     {
       callUntil: 150,
@@ -174,7 +174,7 @@ describe("Throttle function called at 50ms interval.", () => {
       executedTimes: [0, 150, 350, 850, 1850, 2850, 3850, 4850, 5850],
     },
   ])(
-    "Throttle function called until $callUntil ms, it will be executed $executedTimes .",
+    "The throttle function called until $callUntil ms, it will be executed $executedTimes .",
     ({ callUntil, executedTimes }) => {
       // Arrange
       const throttle = createThrottle();
@@ -191,7 +191,7 @@ describe("Throttle function called at 50ms interval.", () => {
     },
   );
 
-  describe("After called at 5 times with 10ms interval.", () => {
+  describe("After called 5 times with 10ms interval.", () => {
     test.each<IntervalTestParameter>([
       {
         callUntil: 50,
@@ -206,7 +206,7 @@ describe("Throttle function called at 50ms interval.", () => {
         executedTimes: [0, 150, 350, 850],
       },
     ])(
-      "Throttle function called until $callUntil ms, it will be executed $executedTimes .",
+      "The throttle function called until $callUntil ms, it will be executed $executedTimes .",
       ({ callUntil, executedTimes }) => {
         // Arrange
         const throttle = createThrottle();
@@ -229,7 +229,7 @@ describe("Throttle function called at 50ms interval.", () => {
   });
 });
 
-describe("Throttle function called at 100ms interval.", () => {
+describe("100ms interval.", () => {
   test.each<IntervalTestParameter>([
     {
       callUntil: 1000,
@@ -262,7 +262,7 @@ describe("Throttle function called at 100ms interval.", () => {
   );
 });
 
-describe("Throttle function called at 1000ms interval.", () => {
+describe("1000ms interval.", () => {
   test.each<IntervalTestParameter>([
     {
       callUntil: 1000,

--- a/packages/location-state-core/src/syncers/navigation-syncer.test.ts
+++ b/packages/location-state-core/src/syncers/navigation-syncer.test.ts
@@ -2,7 +2,7 @@ import { createNavigationMock } from "@repo/test-utils";
 import { describe, expect, test, vi } from "vitest";
 import { NavigationSyncer } from "./navigation-syncer";
 
-describe("NavigationSyncer", () => {
+describe(NavigationSyncer, () => {
   test("The key changes when `navigation.currentEntry` changes.", () => {
     // Arrange
     const navigation = createNavigationMock("/");
@@ -17,7 +17,7 @@ describe("NavigationSyncer", () => {
     expect(key1).not.toBe(key2);
   });
 
-  describe("`sync` listener", () => {
+  describe(NavigationSyncer.prototype.sync, () => {
     test("The listener is called when `currententrychange` event and `event.navigationType` is `push`.", () => {
       // Arrange
       const navigation = createNavigationMock("/");
@@ -97,7 +97,7 @@ describe("NavigationSyncer", () => {
     });
   });
 
-  describe("`updateURL`", () => {
+  describe(NavigationSyncer.prototype.updateURL, () => {
     test("When `updateURL` is called, `navigation.navigate` is called with replace specified.", () => {
       // Arrange
       history.replaceState({ foo: "bar" }, "", "/");

--- a/packages/location-state-core/src/syncers/navigation-syncer.test.ts
+++ b/packages/location-state-core/src/syncers/navigation-syncer.test.ts
@@ -1,109 +1,115 @@
 import { createNavigationMock } from "@repo/test-utils";
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { NavigationSyncer } from "./navigation-syncer";
 
-test("Key changes when `navigation.currentEntry` changes.", () => {
-  // Arrange
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  const key1 = navigationSyncer.key();
-  navigation.navigate("/hoge");
-  // Act
-  const key2 = navigationSyncer.key();
-  // Assert
-  expect(key1).not.toBeUndefined();
-  expect(key2).not.toBeUndefined();
-  expect(key1).not.toBe(key2);
-});
+describe("NavigationSyncer", () => {
+  test("The key changes when `navigation.currentEntry` changes.", () => {
+    // Arrange
+    const navigation = createNavigationMock("/");
+    const navigationSyncer = new NavigationSyncer(navigation);
+    const key1 = navigationSyncer.key();
+    navigation.navigate("/hoge");
+    // Act
+    const key2 = navigationSyncer.key();
+    // Assert
+    expect(key1).not.toBeUndefined();
+    expect(key2).not.toBeUndefined();
+    expect(key1).not.toBe(key2);
+  });
 
-test("Listener is called when `currententrychange` event and `event.navigationType` is `push`.", () => {
-  // Arrange
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  const listener1 = vi.fn();
-  const listener2 = vi.fn();
-  navigationSyncer.sync({
-    listener: listener1,
-    signal: new AbortController().signal,
-  });
-  navigationSyncer.sync({
-    listener: listener2,
-    signal: new AbortController().signal,
-  });
-  // Act
-  navigation.navigate("/hoge");
-  // Assert
-  expect(listener1).toHaveBeenCalledTimes(1);
-  expect(listener2).toHaveBeenCalledTimes(1);
-});
+  describe("`sync` listener", () => {
+    test("The listener is called when `currententrychange` event and `event.navigationType` is `push`.", () => {
+      // Arrange
+      const navigation = createNavigationMock("/");
+      const navigationSyncer = new NavigationSyncer(navigation);
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      navigationSyncer.sync({
+        listener: listener1,
+        signal: new AbortController().signal,
+      });
+      navigationSyncer.sync({
+        listener: listener2,
+        signal: new AbortController().signal,
+      });
+      // Act
+      navigation.navigate("/hoge");
+      // Assert
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
 
-test("Listener is called when `currententrychange` event and `event.navigationType` is `replace`.", () => {
-  // Arrange
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  const listener1 = vi.fn();
-  const listener2 = vi.fn();
-  navigationSyncer.sync({
-    listener: listener1,
-    signal: new AbortController().signal,
-  });
-  navigationSyncer.sync({
-    listener: listener2,
-    signal: new AbortController().signal,
-  });
-  // Act
-  navigation.navigate("/hoge", { history: "replace" });
-  // Assert
-  expect(listener1).toHaveBeenCalledTimes(1);
-  expect(listener2).toHaveBeenCalledTimes(1);
-});
+    test("The listener is called when `currententrychange` event and `event.navigationType` is `replace`.", () => {
+      // Arrange
+      const navigation = createNavigationMock("/");
+      const navigationSyncer = new NavigationSyncer(navigation);
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      navigationSyncer.sync({
+        listener: listener1,
+        signal: new AbortController().signal,
+      });
+      navigationSyncer.sync({
+        listener: listener2,
+        signal: new AbortController().signal,
+      });
+      // Act
+      navigation.navigate("/hoge", { history: "replace" });
+      // Assert
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
 
-test("Listener is not called when `currententrychange` event and `event.navigationType` is `reload`.", () => {
-  // Arrange
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  const listener = vi.fn();
-  navigationSyncer.sync({
-    listener,
-    signal: new AbortController().signal,
-  });
-  // Act
-  navigation.reload();
-  // Assert
-  expect(listener).not.toHaveBeenCalled();
-});
+    test("The listener is not called when `currententrychange` event and `event.navigationType` is `reload`.", () => {
+      // Arrange
+      const navigation = createNavigationMock("/");
+      const navigationSyncer = new NavigationSyncer(navigation);
+      const listener = vi.fn();
+      navigationSyncer.sync({
+        listener,
+        signal: new AbortController().signal,
+      });
+      // Act
+      navigation.reload();
+      // Assert
+      expect(listener).not.toHaveBeenCalled();
+    });
 
-// abort does not work well, but the cause is unknown
-test("After `abort`, listener is called when `currententrychange` event and `event.navigationType` is `push`.", () => {
-  // Arrange
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  const listener1 = vi.fn();
-  const listener2 = vi.fn();
-  const controller = new AbortController();
-  navigationSyncer.sync({ listener: listener1, signal: controller.signal });
-  navigationSyncer.sync({
-    listener: listener2,
-    signal: new AbortController().signal,
+    // abort does not work well, but the cause is unknown
+    test("After `abort`, the listener is called when `currententrychange` event and `event.navigationType` is `push`.", () => {
+      // Arrange
+      const navigation = createNavigationMock("/");
+      const navigationSyncer = new NavigationSyncer(navigation);
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      const controller = new AbortController();
+      navigationSyncer.sync({ listener: listener1, signal: controller.signal });
+      navigationSyncer.sync({
+        listener: listener2,
+        signal: new AbortController().signal,
+      });
+      controller.abort();
+      // Act
+      navigation.navigate("/hoge");
+      // Assert
+      expect(listener1).not.toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalled();
+    });
   });
-  controller.abort();
-  // Act
-  navigation.navigate("/hoge");
-  // Assert
-  expect(listener1).not.toHaveBeenCalled();
-  expect(listener2).toHaveBeenCalled();
-});
 
-test("When `updateURL` called, navigation.navigate` is called with replace specified.", () => {
-  // Arrange
-  history.replaceState({ foo: "bar" }, "", "/");
-  const navigation = createNavigationMock("/");
-  const navigationSyncer = new NavigationSyncer(navigation);
-  // Act
-  navigationSyncer.updateURL("/hoge");
-  // Assert
-  expect(globalThis.history.state).toEqual({
-    foo: "bar",
+  describe("`updateURL`", () => {
+    test("When `updateURL` is called, `navigation.navigate` is called with replace specified.", () => {
+      // Arrange
+      history.replaceState({ foo: "bar" }, "", "/");
+      const navigation = createNavigationMock("/");
+      const navigationSyncer = new NavigationSyncer(navigation);
+      // Act
+      navigationSyncer.updateURL("/hoge");
+      // Assert
+      expect(globalThis.history.state).toEqual({
+        foo: "bar",
+      });
+      expect(location.href).toBe("http://localhost:3000/hoge");
+    });
   });
-  expect(location.href).toBe("http://localhost:3000/hoge");
 });


### PR DESCRIPTION
`StorageStore`のoverload対応時にstorage storeのテスト構造を見直したので、それに合わせる形で全体の単体テスト構造を見直しました。